### PR TITLE
fix: updated concurrency key

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ env:
 concurrency:
   # each new commit to a PR runs this workflow
   # so we need to avoid a long running older one from overwriting the 'pr-<number>-latest'
-  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label }}"
+  group: "${{ github.workflow }} @ ${{ github.ref_name }}"
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Switched to `ref_name` as it is always available, e.g. `main` or `2/merge` in the case of the merge commit of PR 2.