### PR TITLE
renovate config typo fix

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
     "extends": [
         "github>kristof-mattei/renovate-config",
-        "github>kristof-mattei/renovate-config//rust/updateupdateRustVersionInCargoToml",
+        "github>kristof-mattei/renovate-config//rust/updateRustVersionInCargoToml",
         "github>kristof-mattei/renovate-config//rust/updateChannelInRustToolchainToml"
     ]
 }


### PR DESCRIPTION
- chore: also include rust-specific configs
- chore: fixed double update typo
