### PR TITLE
download binstall in tmp

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,6 +90,7 @@ jobs:
       - name: Get binstall
         shell: bash
         run: |
+          cd /tmp
           archive="cargo-binstall-x86_64-unknown-linux-musl.tgz"
           wget "https://github.com/ryankurte/cargo-binstall/releases/latest/download/${archive}"
 


### PR DESCRIPTION
- fix: download binstall to /tmp to avoid additional untracked files
